### PR TITLE
Fix emojis breaking obfuscation

### DIFF
--- a/SOURCEKITISSUES.md
+++ b/SOURCEKITISSUES.md
@@ -20,7 +20,6 @@ These are problems that SourceKit has that are unrelated to a specific feature, 
 **Note: You can use the `--ignore-targets` argument to completely disable the obfuscation of specific targets.**
 
 - (SR-9020)](https://bugs.swift.org/browse/SR-9020) Legacy KeyPaths that include types (like `#keyPath(Foo.bar)`) will not get indexed.
-- Any file that has an emoji will break the obfuscation process. This may not be a SourceKit bug itself, but something that we have to treat on our side.
 - `@objc optional` protocol methods don't have their references indexed.
 
 # Additional important information

--- a/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
+++ b/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
@@ -199,27 +199,28 @@ extension SourceKitObfuscator {
                 // Avoid duplicates.
                 currentReferenceIndex += 1
             }
+            let currentCharacter = charArray[currentCharIndex]
             if line == reference.line, column == reference.column {
                 previousReference = reference
                 let originalName = reference.name
                 let obfuscatedName = obfuscate(name: originalName)
-                let wasInternalKeyword = charArray[currentCharIndex] == "`"
+                let wasInternalKeyword = currentCharacter == "`"
                 for i in 1 ..< (originalName.count + (wasInternalKeyword ? 2 : 0)) {
                     charArray[currentCharIndex + i] = ""
                 }
                 charArray[currentCharIndex] = obfuscatedName
                 currentReferenceIndex += 1
                 currentCharIndex += originalName.count
-                column += originalName.count
+                column += originalName.utf8Count
                 if wasInternalKeyword {
                     charArray[currentCharIndex] = ""
                 }
-            } else if charArray[currentCharIndex] == "\n" {
+            } else if currentCharacter == "\n" {
                 line += 1
                 column = 1
                 currentCharIndex += 1
             } else {
-                column += 1
+                column += currentCharacter.utf8Count
                 currentCharIndex += 1
             }
         }

--- a/Sources/SwiftShieldCore/StringHelpers.swift
+++ b/Sources/SwiftShieldCore/StringHelpers.swift
@@ -68,3 +68,10 @@ extension NSTextCheckingResult {
         return groupStartIndex ..< groupEndIndex
     }
 }
+
+extension String {
+    /// Considers emoji scalars when counting.
+    var utf8Count: Int {
+        return utf8.count
+    }
+}

--- a/Sources/swiftshield/main.swift
+++ b/Sources/swiftshield/main.swift
@@ -4,7 +4,7 @@ import SwiftShieldCore
 
 struct Swiftshield: ParsableCommand {
     static var configuration = CommandConfiguration(
-        abstract: "SwiftShield 4.0.0",
+        abstract: "SwiftShield 4.0.1",
         subcommands: [Obfuscate.self, Deobfuscate.self]
     )
 }


### PR DESCRIPTION
Emojis broke obfuscation because they weren't being treated as UTF8 strings. Getting their UTF8 count instead of `count` solves the issue.

CC @vrujbr