### PR TITLE
xcode12 fix new argument added

### DIFF
--- a/Sources/SwiftShieldCore/ProjectRunner/SchemeInfoProvider.swift
+++ b/Sources/SwiftShieldCore/ProjectRunner/SchemeInfoProvider.swift
@@ -131,7 +131,7 @@ struct SchemeInfoProvider: SchemeInfoProviderProtocol {
             args[indexOfOutputMap] = nil
             args[indexOfOutputMap + 1] = nil
         }
-        let forbiddenArgs = ["-parseable-output", "-incremental", "-serialize-diagnostics", "-emit-dependencies"]
+        let forbiddenArgs = ["-parseable-output", "-incremental", "-serialize-diagnostics", "-emit-dependencies", "-enforce-exclusivity\\=checked"]
         for (index, arg) in args.enumerated() {
             if forbiddenArgs.contains(arg ?? "") {
                 args[index] = nil


### PR DESCRIPTION
make swiftshield in ExampleProject works with "-enforce-exclusivity\\=checked" added to forbiddenArgs. 