### PR TITLE
Ignore names script option

### DIFF
--- a/Sources/SwiftShieldCore/Controller/SwiftShieldAssembler.swift
+++ b/Sources/SwiftShieldCore/Controller/SwiftShieldAssembler.swift
@@ -5,6 +5,7 @@ public enum SwiftSwiftAssembler {
         projectPath: String,
         scheme: String,
         modulesToIgnore: Set<String>,
+        namesToIgnore: Set<String>,
         ignorePublic: Bool,
         dryRun: Bool,
         verbose: Bool,
@@ -30,6 +31,7 @@ public enum SwiftSwiftAssembler {
             sourceKit: sourceKit,
             logger: logger,
             dataStore: .init(),
+            namesToIgnore: namesToIgnore,
             ignorePublic: ignorePublic
         )
 

--- a/Sources/SwiftShieldCore/ProjectRunner/SchemeInfoProvider.swift
+++ b/Sources/SwiftShieldCore/ProjectRunner/SchemeInfoProvider.swift
@@ -139,6 +139,8 @@ struct SchemeInfoProvider: SchemeInfoProviderProtocol {
                 args[index] = "-Onone"
             } else if arg == "-DNDEBUG=1" {
                 args[index] = "-DDEBUG=1"
+            } else if arg == "-DDEBUG\\=1" {
+                args[index] = "-DDEBUG=1"
             }
         }
         args.append(contentsOf: ["-D", "DEBUG"])

--- a/Sources/swiftshield/main.swift
+++ b/Sources/swiftshield/main.swift
@@ -19,6 +19,9 @@ extension Swiftshield {
 
         @Option(name: .shortAndLong, help: "A list of targets, separated by a comma, that should NOT be obfuscated.")
         var ignoreTargets: String?
+        
+        @Option(name: .shortAndLong, help: "A list of names, separated by a comma, that should NOT be obfuscated.")
+        var ignoreNames: String?
 
         @Flag(help: "Don't obfuscate content that is 'public' or 'open' (a.k.a 'SDK Mode').")
         var ignorePublic: Bool
@@ -34,9 +37,11 @@ extension Swiftshield {
 
         func run() throws {
             let modulesToIgnore = Set((ignoreTargets ?? "").components(separatedBy: ","))
+            let namesToIgnore = Set((ignoreNames ?? "").components(separatedBy: ","))
             let runner = SwiftSwiftAssembler.generate(
                 projectPath: projectFile, scheme: scheme,
                 modulesToIgnore: modulesToIgnore,
+                namesToIgnore: namesToIgnore,
                 ignorePublic: ignorePublic,
                 dryRun: dryRun,
                 verbose: verbose,

--- a/Tests/SwiftShieldTests/FeatureTestUtils.swift
+++ b/Tests/SwiftShieldTests/FeatureTestUtils.swift
@@ -45,7 +45,8 @@ func testModule(
     return try provider.getModulesFromProject().first!
 }
 
-func baseTestData(ignorePublic: Bool = false) -> (SourceKitObfuscator, SourceKitObfuscatorDataStore, ObfuscatorDelegateSpy) {
+func baseTestData(ignorePublic: Bool = false,
+                  namesToIgnore: Set<String> = []) -> (SourceKitObfuscator, SourceKitObfuscatorDataStore, ObfuscatorDelegateSpy) {
     let logger = Logger()
     let sourceKit = SourceKit(logger: logger)
     let dataStore = SourceKitObfuscatorDataStore()
@@ -53,6 +54,7 @@ func baseTestData(ignorePublic: Bool = false) -> (SourceKitObfuscator, SourceKit
         sourceKit: sourceKit,
         logger: logger,
         dataStore: dataStore,
+        namesToIgnore: namesToIgnore,
         ignorePublic: ignorePublic
     )
     let delegateSpy = ObfuscatorDelegateSpy()

--- a/Tests/SwiftShieldTests/FeatureTests.swift
+++ b/Tests/SwiftShieldTests/FeatureTests.swift
@@ -28,7 +28,7 @@ final class FeatureTests: XCTestCase {
     }
 
     func test_CodingKeys_isIgnored() throws {
-        let (obfs, store, delegate) = baseTestData()
+        let (obfs, store, delegate) = baseTestData(namesToIgnore: ["FooCodingKeys"])
         let module = try testModule(withContents: """
         struct Foo: Codable {
             enum FooCodingKeys: CodingKey {
@@ -59,7 +59,7 @@ final class FeatureTests: XCTestCase {
 
         XCTAssertEqual(delegate.receivedContent[modifiableFilePath], """
         struct OBS1: Codable {
-            enum OBS9: CodingKey {
+            enum FooCodingKeys: CodingKey {
                 case a
                 case b
                 case c

--- a/Tests/SwiftShieldTests/FeatureTests.swift
+++ b/Tests/SwiftShieldTests/FeatureTests.swift
@@ -28,7 +28,7 @@ final class FeatureTests: XCTestCase {
     }
 
     func test_CodingKeys_isIgnored() throws {
-        let (obfs, store, delegate) = baseTestData(namesToIgnore: ["FooCodingKeys"])
+        let (obfs, store, delegate) = baseTestData()
         let module = try testModule(withContents: """
         struct Foo: Codable {
             enum FooCodingKeys: CodingKey {
@@ -59,7 +59,7 @@ final class FeatureTests: XCTestCase {
 
         XCTAssertEqual(delegate.receivedContent[modifiableFilePath], """
         struct OBS1: Codable {
-            enum FooCodingKeys: CodingKey {
+            enum OBS9: CodingKey {
                 case a
                 case b
                 case c
@@ -68,6 +68,46 @@ final class FeatureTests: XCTestCase {
                 case OBS5
                 case OBS6
                 case OBS7
+            }
+        }
+        """)
+    }
+    
+    func test_NamesToIgnore() throws {
+        let (obfs, store, delegate) = baseTestData(namesToIgnore: ["IgnoreClassName",
+                                                                   "CodingKeys"])
+        let module = try testModule(withContents: """
+        import Foundation
+
+        class IgnoreClassName: NSObject {}
+
+        struct Foo: Codable {
+            let a: String
+            
+            enum CodingKeys: String, CodingKey {
+                case a
+            }
+        }
+        """)
+        
+        store.obfuscationDictionary["IgnoreClassName"] = "OBS1"
+        store.obfuscationDictionary["Foo"] = "OBS2"
+        store.obfuscationDictionary["a"] = "OBS3"
+        store.obfuscationDictionary["CodingKeys"] = "OBS4"
+
+        try obfs.registerModuleForObfuscation(module)
+        try obfs.obfuscate()
+
+        XCTAssertEqual(delegate.receivedContent[modifiableFilePath], """
+        import Foundation
+
+        class IgnoreClassName: NSObject {}
+
+        struct OBS2: Codable {
+            let a: String
+            
+            enum CodingKeys: String, CodingKey {
+                case a
             }
         }
         """)

--- a/Tests/SwiftShieldTests/SourceKitObfuscatorTests.swift
+++ b/Tests/SwiftShieldTests/SourceKitObfuscatorTests.swift
@@ -5,7 +5,7 @@ final class SourceKitObfuscatorTests: XCTestCase {
     func test_moduleRegistration() throws {
         let sourceKit = SourceKit(logger: DummyLogger())
         let dataStore = SourceKitObfuscatorDataStore()
-        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, ignorePublic: false)
+        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, namesToIgnore: [], ignorePublic: false)
 
         let module = try testModule(withContents: "final class Foo {}")
 
@@ -118,7 +118,7 @@ final class SourceKitObfuscatorTests: XCTestCase {
     func test_obfuscation_cachesStrings() {
         let sourceKit = SourceKit(logger: DummyLogger())
         let dataStore = SourceKitObfuscatorDataStore()
-        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, ignorePublic: false)
+        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, namesToIgnore: [], ignorePublic: false)
 
         let fooString = "fooString"
         XCTAssertNil(dataStore.obfuscationDictionary[fooString])
@@ -150,7 +150,7 @@ final class SourceKitObfuscatorTests: XCTestCase {
 
         let sourceKit = SourceKit(logger: DummyLogger())
         let dataStore = SourceKitObfuscatorDataStore()
-        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, ignorePublic: false)
+        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, namesToIgnore: [], ignorePublic: false)
 
         dataStore.obfuscationDictionary["Foo"] = "AAAA"
         dataStore.obfuscationDictionary["default"] = "BBBB"
@@ -176,7 +176,7 @@ final class SourceKitObfuscatorTests: XCTestCase {
 
         let sourceKit = SourceKit(logger: DummyLogger())
         let dataStore = SourceKitObfuscatorDataStore()
-        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, ignorePublic: false)
+        let obfuscator = SourceKitObfuscator(sourceKit: sourceKit, logger: DummyLogger(), dataStore: dataStore, namesToIgnore: [], ignorePublic: false)
 
         dataStore.obfuscationDictionary["Foo"] = "AAAA"
         dataStore.obfuscationDictionary["default"] = "BBBB"


### PR DESCRIPTION
### Problem
SwiftShield obfuscates the following names:
- "class names" which are used in storyboard, xibs
- "CodingKeys" used by models

Which generates build, runtime errors.

### Solution
New script option, **--ignore-names** where you pass the names which should not be obfuscated by SwiftShield.

**example**
`swiftshield obfuscate --project-file YourProduct.xcodeproj --scheme YourProduct --ignore-names IBViewName1,IBViewName2,CodingKeys`

### Tested
- swiftshield 4.0.3 + ignore-names option
- swiftshield 4.1.1 + ignore-names option
- Xcode 11

With version 4.1.1 I have some properties (2-3, not too many) which are not being obfuscated.
But the ignore names option it's working.