### PR TITLE
Adding the SWIFTSHIELDED property in the build settings in a more resilient way 

### DIFF
--- a/Sources/SwiftShieldCore/Project.swift
+++ b/Sources/SwiftShieldCore/Project.swift
@@ -8,11 +8,11 @@ struct Project: Hashable {
 
     func markAsSwiftShielded() throws -> String {
         var data = try pbxProj.read()
-        let matches = data.match(regex: "PRODUCT_NAME = \".*\";")
+        let matches = data.match(regex: "buildSettings = \\{")
         for match in matches.reversed() {
             let value = match.captureGroup(0, originalString: data)
             let range = match.captureGroupRange(0, originalString: data)
-            let newValue = value + "SWIFTSHIELDED = true;"
+            let newValue = value + "\n" + "SWIFTSHIELDED = true;"
             data = data.replacingCharacters(in: range, with: newValue)
         }
         return data

--- a/Tests/SwiftShieldTests/ProjectTests.swift
+++ b/Tests/SwiftShieldTests/ProjectTests.swift
@@ -39,11 +39,13 @@ final class ProjectTests: XCTestCase {
 
     func test_projectTagging() throws {
         let projectContent = """
+        buildSettings = {
         LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
         OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-D\" \"TESTS\"";
         PRODUCT_BUNDLE_IDENTIFIER = com.rockbruno.MarketplaceTests;
         PRODUCT_NAME = "$(TARGET_NAME)";
         PROVISIONING_PROFILE_SPECIFIER = "";
+        }
         """
         let projTemp = temporaryFilePath(forFile: "foo.xcodeproj")
         try? FileManager.default.createDirectory(
@@ -59,11 +61,14 @@ final class ProjectTests: XCTestCase {
         let result = try projectFile.markAsSwiftShielded()
 
         XCTAssertEqual(result, """
+        buildSettings = {
+        SWIFTSHIELDED = true;
         LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
         OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-D\" \"TESTS\"";
         PRODUCT_BUNDLE_IDENTIFIER = com.rockbruno.MarketplaceTests;
-        PRODUCT_NAME = "$(TARGET_NAME)";SWIFTSHIELDED = true;
+        PRODUCT_NAME = "$(TARGET_NAME)";
         PROVISIONING_PROFILE_SPECIFIER = "";
+        }
         """)
     }
 }


### PR DESCRIPTION
The property ```SWIFTSHIELDED```  was added to the prj file looking ```PRODUCT_NAME``` in some cases this property might not be present in the build settngs and so the project was not flagged as already obfuscated.

This PR address the issue looking instead directly for the ```buildSettings``` string.