### PR TITLE
Public static var/func not identified as public if exported to objc

### DIFF
--- a/Sources/SwiftShieldCore/BaseModels/AccessControl.swift
+++ b/Sources/SwiftShieldCore/BaseModels/AccessControl.swift
@@ -7,3 +7,11 @@ enum AccessControl: String {
     case `fileprivate` = "source.decl.attribute.fileprivate"
     case `internal` = "source.decl.attribute.internal"
 }
+
+//see tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+enum EffectiveAccess: String {
+    case `public` = "source.decl.effective_access.public"
+    case `internal` = "source.decl.effective_access.internal"
+    case `filePrivate` = "source.decl.effective_access.fileprivate"
+    case lessThanFilePrivate = "source.decl.effective_access.less_than_fileprivate"
+}

--- a/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
+++ b/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
@@ -318,7 +318,7 @@ extension SKResponseDictionary {
             return parent.isPublic
         }
         
-        if let effectiveACL: SKUID = self[sourcekitd.keys.effectiveAccess], effectiveACL.asString == "source.decl.effective_access.public" {
+        if let effectiveACL: SKUID = self[sourcekitd.keys.effectiveAccess], effectiveACL.asString == EffectiveAccess.public.rawValue {
             return true
         }
         

--- a/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
+++ b/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
@@ -317,6 +317,11 @@ extension SKResponseDictionary {
         if let kindId: SKUID = self[sourcekitd.keys.kind], let type = kindId.declarationType(), type == .enumelement {
             return parent.isPublic
         }
+        
+        if let effectiveACL: SKUID = self[sourcekitd.keys.effectiveAccess], effectiveACL.asString == "source.decl.effective_access.public" {
+            return true
+        }
+        
         guard let attributes: SKResponseArray = self[sourcekitd.keys.attributes] else {
             return false
         }

--- a/Sources/SwiftShieldCore/SourceKit/SourceKit.swift
+++ b/Sources/SwiftShieldCore/SourceKit/SourceKit.swift
@@ -223,6 +223,7 @@ public struct sourcekitd_keys {
     let attributes: sourcekitd_uid_t
     let attribute: sourcekitd_uid_t
     let related: sourcekitd_uid_t
+    let effectiveAccess: sourcekitd_uid_t
 
     init(api: sourcekitd_functions_t) {
         request = api.uid_get_from_cstr("key.request")!
@@ -265,6 +266,7 @@ public struct sourcekitd_keys {
         attributes = api.uid_get_from_cstr("key.attributes")!
         attribute = api.uid_get_from_cstr("key.attribute")!
         related = api.uid_get_from_cstr("key.related")!
+        effectiveAccess = api.uid_get_from_cstr("key.effective_access")!
     }
 }
 

--- a/Tests/SwiftShieldTests/FeatureTests.swift
+++ b/Tests/SwiftShieldTests/FeatureTests.swift
@@ -189,6 +189,11 @@ final class FeatureTests: XCTestCase {
         public enum Bla {
             case abc
         }
+        
+        @objc public protocol Ignored13 {
+            static func ignored14()
+            static var ignored15: Int { get }
+        }
 
         //Broken.
         //public extension Int {
@@ -201,6 +206,7 @@ final class FeatureTests: XCTestCase {
         store.obfuscationDictionary["NotIgnored2"] = "OBS2"
         store.obfuscationDictionary["notIgnored3"] = "OBS3"
         store.obfuscationDictionary["notIgnored4"] = "OBS4"
+        store.obfuscationDictionary["Ignored13"] = "OBS5"
 
         try obfs.registerModuleForObfuscation(module)
         try obfs.obfuscate()
@@ -235,6 +241,11 @@ final class FeatureTests: XCTestCase {
             case abc
         }
 
+        @objc public protocol Ignored13 {
+            static func ignored14()
+            static var ignored15: Int { get }
+        }
+        
         //Broken.
         //public extension Int {
         //    func ignored5() {}


### PR DESCRIPTION
Given a protocol defined as 
```swift
@objc public protocol AProtocol {
   static func pubfunction()
   static var pubvariable: Int { get }
}
```

SourceKit do not reports the right ACL in the attributes list. The right ACL is resported instead in `key.effective_access`

```
key.entities: [
        {
          key.kind: source.lang.swift.decl.function.method.static,
          key.name: "decision()",
          key.usr: "c:@M@Module@objc(pl)Name(cm)pubfunction",
          key.line: 23,
          key.column: 17,
          key.attributes: [
            {
              key.attribute: source.decl.attribute.objc
            }
          ],
          key.effective_access: source.decl.effective_access.public
        },
......
```

This MR try to address this behaviour looking into the `effective_access` property to identify public entities in SDK mode.