### PR TITLE
Add support for directories/files names with spaces

### DIFF
--- a/Sources/SwiftShieldCore/ProjectRunner/SchemeInfoProvider.swift
+++ b/Sources/SwiftShieldCore/ProjectRunner/SchemeInfoProvider.swift
@@ -85,7 +85,7 @@ struct SchemeInfoProvider: SchemeInfoProviderProtocol {
         if let swiftFileList = swiftFileList {
             let swiftFilePaths = try swiftFileList.read()
                 .components(separatedBy: "\n")
-                .filter { !$0.isEmpty }
+                .filter { !$0.isEmpty }.map{ $0.removeEscapedSpaces }
 
             if let complieFlagIndex = compilerArguments.firstIndex(of: "-c") {
                 var insertIndex = complieFlagIndex

--- a/Sources/SwiftShieldCore/StringHelpers.swift
+++ b/Sources/SwiftShieldCore/StringHelpers.swift
@@ -46,6 +46,10 @@ extension String {
     var replacingEscapedSpaces: String {
         replacingOccurrences(of: "\\ ", with: spacedFolderPlaceholder)
     }
+    
+    var removeEscapedSpaces: String {
+        replacingOccurrences(of: "\\ ", with: " ")
+    }
 
     var removingPlaceholder: String {
         replacingOccurrences(of: spacedFolderPlaceholder, with: " ")


### PR DESCRIPTION
**Reason:**
SourceKit's send_request_sync() fails and returns "error opening input file xxx- No such file or directory", if the folder or file names include escape(\\) in front of the space character. 
**Fix:**
Remove escape(\\) character in front of space before processing.