### PR TITLE
Ignore children of public protocols

### DIFF
--- a/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
+++ b/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
@@ -317,6 +317,9 @@ extension SKResponseDictionary {
         if let kindId: SKUID = self[sourcekitd.keys.kind], let type = kindId.declarationType(), type == .enumelement {
             return parent.isPublic
         }
+        if let kindId: SKUID = parent[sourcekitd.keys.kind], let type = kindId.declarationType(), type == .protocol {
+            return parent.isPublic
+        }
         guard let attributes: SKResponseArray = self[sourcekitd.keys.attributes] else {
             return false
         }


### PR DESCRIPTION
I think public protocols' children should also be considered public so as not to get obfuscated in SDK mode.
I'm wondering: it's highly unlikely that no one's gone through this problem before me. Am I missing something? 

Cheers, Bruno! 🚀 