### PR TITLE
Added support for phantom types

### DIFF
--- a/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
+++ b/Sources/SwiftShieldCore/Obfuscator/SourceKitObfuscator.swift
@@ -293,11 +293,14 @@ extension SourceKitObfuscator {
         req[keys.sourcefile] = file.path
         let cursorInfo = try sourceKit.sendSync(req)
         guard let annotation: String = cursorInfo[keys.annotated_decl] else {
-            logger.log("Pretending \(usr) inherits from Codable because SourceKit failed to look it up. This can happen if this USR belongs to an @objc class.", verbose: true)
-            return result(true)
+            if usr.hasPrefix("c:") {
+                logger.log("Pretending \(usr) inherits from Codable because SourceKit failed to look it up. This can happen if this USR belongs to an @objc class.", verbose: true)
+                return result(true)
+            }
+            return result(false)
         }
         let regex = "usr=\\\"(.\\S*)\\\""
-        let regexResult = annotation.match(regex: regex)
+        let regexResult = annotation.components(separatedBy: " where ")[0].match(regex: regex)
         for res in regexResult {
             let inheritedUSR = res.captureGroup(1, originalString: annotation)
             if usrs.contains(inheritedUSR) {

--- a/Tests/SwiftShieldTests/SourceKitObfuscatorTests.swift
+++ b/Tests/SwiftShieldTests/SourceKitObfuscatorTests.swift
@@ -191,4 +191,69 @@ final class SourceKitObfuscatorTests: XCTestCase {
         }
         """)
     }
+    
+    func test_phantomTypeConformingToProtocol_sendsCorrectObfuscatedFileContentToDelegate() throws {
+        let (obfs, store, delegate) = baseTestData()
+        let module = try testModule(withContents: """
+        protocol SomeProtocol {}
+        struct SomeStruct<T: SomeProtocol> {
+            var someBool: Bool {
+                return true
+            }
+        }
+        """)
+
+        store.obfuscationDictionary["SomeProtocol"] = "OBS1"
+        store.obfuscationDictionary["SomeStruct"] = "OBS2"
+        store.obfuscationDictionary["someBool"] = "OBS3"
+
+        try obfs.registerModuleForObfuscation(module)
+        try obfs.obfuscate()
+
+        XCTAssertEqual(delegate.receivedContent[modifiableFilePath], """
+        protocol OBS1 {}
+        struct OBS2<T: OBS1> {
+            var OBS3: Bool {
+                return true
+            }
+        }
+        """)
+        XCTAssertEqual(delegate.receivedContent.count, 3)
+    }
+    
+    func test_phantomTypeConformingToProtocolWithWhereClause_sendsCorrectObfuscatedFileContentToDelegate() throws {
+        let (obfs, store, delegate) = baseTestData()
+        let module = try testModule(withContents: """
+        struct Foo {}
+        protocol SomeProtocol {
+            associatedtype Item
+        }
+        struct SomeStruct<T: SomeProtocol> where T.Item == Foo {
+            var someBool: Bool {
+                return true
+            }
+        }
+        """)
+
+        store.obfuscationDictionary["SomeProtocol"] = "OBS1"
+        store.obfuscationDictionary["SomeStruct"] = "OBS2"
+        store.obfuscationDictionary["someBool"] = "OBS3"
+        store.obfuscationDictionary["Foo"] = "OBS4"
+
+        try obfs.registerModuleForObfuscation(module)
+        try obfs.obfuscate()
+
+        XCTAssertEqual(delegate.receivedContent[modifiableFilePath], """
+        struct OBS4 {}
+        protocol OBS1 {
+            associatedtype Item
+        }
+        struct OBS2<T: OBS1> where T.Item == OBS4 {
+            var OBS3: Bool {
+                return true
+            }
+        }
+        """)
+        XCTAssertEqual(delegate.receivedContent.count, 3)
+    }
 }


### PR DESCRIPTION
This PR is adding support for phantom types. We experienced that phantom types were incorrectly treated as Codable parent classes. 